### PR TITLE
Utility to list Direct Play registered applications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ DLL_SOURCES = $(shell echo dll/*.c)
 DLL_HEADERS = $(shell echo dll/*.h)
 DLL_OBJECTS = $(DLL_SOURCES:.c=.o) debug.o
 ENUMERATE_SOURCES = $(shell echo *.c) cli/dpenumerate.c cli/dpwrap.c
-ENUMERATE_OBJECTS = $(SOURCES:.c=.o)
+ENUMERATE_OBJECTS = $(ENUMERATE_SOURCES:.c=.o)
 
 all: bin/debug/dprun.exe bin/release/dprun.exe bin/debug/dpenumerate.exe bin/release/dpenumerate.exe
 	@echo "Sizes:"

--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,26 @@ LDFLAGS = -ldplayx -lole32 -lws2_32 -luuid
 OPTFLAGS = -O3 -s
 DBGFLAGS = -DDEBUG -g
 
-SOURCES = $(shell echo *.c cli/*.c)
+SOURCES = $(shell echo *.c) cli/dpsp.c cli/dpwrap.c cli/main.c cli/session.c
 HEADERS = $(shell echo *.h cli/*.h)
 OBJECTS = $(SOURCES:.c=.o)
 DLL_SOURCES = $(shell echo dll/*.c)
 DLL_HEADERS = $(shell echo dll/*.h)
 DLL_OBJECTS = $(DLL_SOURCES:.c=.o) debug.o
+ENUMERATE_SOURCES = $(shell echo *.c) cli/dpenumerate.c cli/dpwrap.c
+ENUMERATE_OBJECTS = $(SOURCES:.c=.o)
 
-all: bin/debug/dprun.exe bin/release/dprun.exe
+all: bin/debug/dprun.exe bin/release/dprun.exe bin/debug/dpenumerate.exe bin/release/dpenumerate.exe
 	@echo "Sizes:"
-	@ls -sh1 bin/debug/dprun.exe bin/debug/dprun.dll \
-			   bin/release/dprun.exe bin/release/dprun.dll
-debug: bin/debug/dprun.exe
-release: bin/release/dprun.exe
+	@ls -sh1 bin/debug/dprun.exe bin/debug/dpenumerate.exe bin/debug/dprun.dll \
+			   bin/release/dprun.exe bin/release/dpenumerate.exe bin/release/dprun.dll
+debug: bin/debug/dprun.exe bin/debug/dpenumerate.exe
+release: bin/release/dprun.exe bin/release/dpenumerate.exe
 
 clean:
-	rm -f $(OBJECTS)
+	rm -f $(OBJECTS) $(DLL_OBJECTS) $(ENUMERATE_OBJECTS)
 	rm -f *.plist
-	rm -f bin/debug/dprun.exe bin/release/dprun.exe
+	rm -f bin/debug/dprun.exe bin/release/dprun.exe bin/debug/dpenumerate.exe bin/release/dpenumerate.exe
 
 .PHONY: all debug release clean
 
@@ -42,15 +44,20 @@ bin/debug/dprun.dll: bin/debug $(DLL_OBJECTS)
 	$(CC) -o $@ $(CFLAGS) $(DBGFLAGS) -shared $(DLL_OBJECTS) $(LDFLAGS)
 bin/debug/dprun.exe: bin/debug/dprun.dll $(OBJECTS)
 	$(CC) -o $@ $(CFLAGS) $(DBGFLAGS) $(OBJECTS) $(LDFLAGS)
+bin/debug/dpenumerate.exe: $(ENUMERATE_OBJECTS)
+	$(CC) -o $@ $(CFLAGS) $(DBGFLAGS) $(ENUMERATE_OBJECTS) $(LDFLAGS)
 
 bin/release/dprun.dll: bin/release $(DLL_OBJECTS)
 	$(CC) -o $@ $(CFLAGS) $(OPTFLAGS) -shared $(DLL_OBJECTS) $(LDFLAGS)
 bin/release/dprun.exe: bin/release/dprun.dll $(OBJECTS)
 	$(CC) -o $@ $(CFLAGS) $(OPTFLAGS) -static $(OBJECTS) $(LDFLAGS)
+bin/release/dpenumerate.exe: $(ENUMERATE_OBJECTS)
+	$(CC) -o $@ $(CFLAGS) $(OPTFLAGS) -static $(ENUMERATE_OBJECTS) $(LDFLAGS)
 
 lint:
 	clang --analyze $(SOURCES) -I./include -I/usr/include/wine/windows/
 	clang --analyze $(DLL_SOURCES) -I./include -I/usr/include/wine/windows/
+	clang --analyze $(ENUMERATE_SOURCES) -I./include -I/usr/include/wine/windows/
 
 run: bin/debug/dprun.exe
 	wine bin/debug/dprun.exe

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ The DPRun Service Provider needs some metadata to identify the players that send
 
 Further documentation on the socket API may follow :)
 
+## dpenumerate
+
+List applications registered with directplay.
+
+```
+dpenumerate [options]
+
+Options:
+  -c, --csv
+      CSV output.
+```
+
 ## Building
 
 ### Linux

--- a/cli/dpenumerate.c
+++ b/cli/dpenumerate.c
@@ -1,6 +1,7 @@
 #include "../shared.h"
 #include <stdio.h>
 #include <dplobby.h>
+#include <getopt.h>
 #include "dpwrap.h"
 #include "../debug.h"
 
@@ -23,8 +24,8 @@ static const char* help_text =
   "      CSV output.\n";
 
 
-BOOL FAR PASCAL application_print_callback(LPCDPLAPPINFO lpAppInfo,  LPVOID format,  DWORD dwFlags) {
-  outputfmt format = *((*otuputfmt) format);
+BOOL FAR PASCAL application_print_callback(LPCDPLAPPINFO lpAppInfo,  LPVOID lpContext,  DWORD dwFlags) {
+  enum outputfmt format = * (enum outputfmt*) lpContext;
   char guid[GUID_STR_LEN];
   guid_stringify(&lpAppInfo->guidApplication, guid);
 
@@ -34,7 +35,7 @@ BOOL FAR PASCAL application_print_callback(LPCDPLAPPINFO lpAppInfo,  LPVOID form
       break;
 
     default:
-      printf("  - '%s': '%s'\n", lpAppInfo->lpszAppNameA, guid);
+      printf("  - %s: %s\n", lpAppInfo->lpszAppNameA, guid);
       break;
   }
 
@@ -43,7 +44,7 @@ BOOL FAR PASCAL application_print_callback(LPCDPLAPPINFO lpAppInfo,  LPVOID form
 
 int main(int argc, char** argv) {
   int opt_index = 0;
-  outputfmt format = OUTPUT_FMT_DEFAULT;
+  enum outputfmt format = OUTPUT_FMT_DEFAULT;
 
   switch (getopt_long(argc, argv, "hc", long_options, &opt_index)) {
     case 'c':

--- a/cli/dpenumerate.c
+++ b/cli/dpenumerate.c
@@ -1,0 +1,84 @@
+#include "../shared.h"
+#include <stdio.h>
+#include <dplobby.h>
+#include "dpwrap.h"
+#include "../debug.h"
+
+enum outputfmt {
+    OUTPUT_FMT_DEFAULT,
+    OUTPUT_FMT_CSV
+};
+
+static struct option long_options[] = {
+  {"help", no_argument, NULL, 'h'},
+  {"csv", no_argument, NULL, 'c'},
+  {0, 0, 0, 0},
+};
+
+static const char* help_text =
+  "dpenumerate [options]\n"
+  "\n"
+  "Options:\n"
+  "  -c, --csv\n"
+  "      CSV output.\n";
+
+
+BOOL FAR PASCAL application_print_callback(LPCDPLAPPINFO lpAppInfo,  LPVOID format,  DWORD dwFlags) {
+  outputfmt format = *((*otuputfmt) format);
+  char guid[GUID_STR_LEN];
+  guid_stringify(&lpAppInfo->guidApplication, guid);
+
+  switch (format) {
+    case OUTPUT_FMT_CSV:
+      printf("%s,%s\n", lpAppInfo->lpszAppNameA, guid);
+      break;
+
+    default:
+      printf("  - '%s': '%s'\n", lpAppInfo->lpszAppNameA, guid);
+      break;
+  }
+
+  return TRUE;
+}
+
+int main(int argc, char** argv) {
+  int opt_index = 0;
+  outputfmt format = OUTPUT_FMT_DEFAULT;
+
+  switch (getopt_long(argc, argv, "hc", long_options, &opt_index)) {
+    case 'c':
+      format = OUTPUT_FMT_CSV;
+      break;
+
+    case 'h':
+      printf(help_text);
+      return 0;
+
+    default:
+      break;
+  }
+
+  LPDIRECTPLAYLOBBY3A lobby = NULL;
+
+  HRESULT result = dplobby_create(&lobby);
+  CHECK("dplobby_create", result);
+
+  switch (format) {
+    case OUTPUT_FMT_CSV:
+      printf("ApplicationName,GUID\n");
+      break;
+
+    default:
+      printf("Applications registered with DirectPlay:\n");
+      break;
+  }
+
+  result = lobby->lpVtbl->EnumLocalApplications(lobby, application_print_callback, (LPVOID) &format, 0);
+
+  if (FAILED(result)) {
+    printf("Could not enumerate local applications: %s\n", get_error_message(result));
+    return 1;
+  }
+
+  return 0;
+}


### PR DESCRIPTION
The PR introduce another command line utility called `dpenumerate`.

This binary list all the direct play registered applications with its guid.

```
> .\bin\debug\dpenumerate.exe
Applications registered with DirectPlay:
  - Age of Empires II - The Conquerors Expansion: {5DE93F3F-FC90-4EE1-AE5A-63DAFA055950}
```